### PR TITLE
Add M5 Atom RTSP audio streaming example

### DIFF
--- a/Atom/m5 Sx/M5 Atom rtsp/README.md
+++ b/Atom/m5 Sx/M5 Atom rtsp/README.md
@@ -1,0 +1,27 @@
+# M5 Atom RTSP Microphone
+
+Streams audio from an M5 Atom with the SPM1423 PDM microphone over RTSP using TCP transport.
+
+## Wiring
+- `3V3` ↔ `3V3`
+- `GND` ↔ `GND`
+- `CLK` ↔ `GPIO22`
+- `DATA` ↔ `GPIO23`
+
+## Build & Upload
+```bash
+pio run --target upload
+```
+
+## Monitor
+```bash
+pio device monitor
+```
+
+## Play the Stream
+On another machine:
+```bash
+ffplay rtsp://<board-ip>/mic
+# or
+vlc rtsp://<board-ip>/mic
+```

--- a/Atom/m5 Sx/M5 Atom rtsp/platformio.ini
+++ b/Atom/m5 Sx/M5 Atom rtsp/platformio.ini
@@ -1,14 +1,10 @@
-; PlatformIO Project Configuration File
-;
-;   Build options: build flags, source filter
-;   Upload options: custom upload port, speed and extra flags
-;   Library options: dependencies, extra library storages
-;   Advanced options: extra scripting
-;
-; Please visit documentation for the other options and examples
-; https://docs.platformio.org/page/projectconf.html
-
 [env:m5stack-atom]
-platform = espressif32
-board = m5stack-atom
-framework = arduino
+platform    = espressif32
+board       = m5stack-atom
+framework   = arduino
+monitor_speed = 115200
+
+lib_deps =
+    m5stack/M5Unified
+    pschatzmann/arduino-audio-tools
+    techtanium/ESP32 RTSP Server

--- a/Atom/m5 Sx/M5 Atom rtsp/src/main.cpp
+++ b/Atom/m5 Sx/M5 Atom rtsp/src/main.cpp
@@ -1,18 +1,42 @@
 #include <Arduino.h>
+#include <WiFi.h>
+#include <M5Unified.h>
+#include "AudioTools.h"
+#include "AudioLibs/RTSPServer.h"
 
-// put function declarations here:
-int myFunction(int, int);
+// WiFi credentials
+const char* ssid     = "YOUR_SSID";
+const char* password = "YOUR_PASSWORD";
+
+// Audio configuration: 16 kHz mono, 16-bit
+AudioInfo   audioInfo(16000, 1, 16);
+I2SStream   i2sStream;
+RTSPServer  rtsp(audioInfo, i2sStream);
 
 void setup() {
-  // put your setup code here, to run once:
-  int result = myFunction(2, 3);
+  M5.begin();
+  Serial.begin(115200);
+
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(100);
+  }
+
+  I2SConfig cfg = i2sStream.defaultConfig(RX_MODE_PDM);
+  cfg.pin_ws   = 22;  // Clock pin
+  cfg.pin_data = 23;  // Data pin
+  cfg.sample_rate = audioInfo.sample_rate;
+  cfg.bits_per_sample = audioInfo.bits_per_sample;
+  cfg.channels = audioInfo.channels;
+  i2sStream.begin(cfg);
+
+  rtsp.setDefaultTransport(Transport::TCP);
+  rtsp.begin("mic");
+
+  Serial.printf("RTSP URL: rtsp://%s/mic\n", WiFi.localIP().toString().c_str());
 }
 
 void loop() {
-  // put your main code here, to run repeatedly:
-}
-
-// put function definitions here:
-int myFunction(int x, int y) {
-  return x + y;
+  rtsp.handleClient();
+  rtsp.write(i2sStream);
 }


### PR DESCRIPTION
## Summary
- Configure PlatformIO project for M5 Atom with required libraries
- Implement RTSP server that streams audio from PDM mic over TCP
- Document wiring and usage instructions

## Testing
- `pio run` *(fails: HTTPClientError while installing espressif32 platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a035ee9190832c83eb3c4770479774