### PR TITLE
Fix PDM mic I2S setup and sample reading

### DIFF
--- a/Atom/m5 Sx/M5 Atom rtsp/src/main.cpp
+++ b/Atom/m5 Sx/M5 Atom rtsp/src/main.cpp
@@ -20,7 +20,8 @@ void setup() {
   while (WiFi.status() != WL_CONNECTED) delay(100);
 
   // Configure I2S in PDM mode
-  I2SConfig cfg = i2sStream.defaultConfig(RX_MODE_PDM);
+  I2SConfig cfg = i2sStream.defaultConfig(RX_MODE);
+  cfg.signal_type = PDM;
   cfg.pin_ws   = 22;     // CLK (change to your pin)
   cfg.pin_data = 23;     // DATA (change to your pin)
   cfg.sample_rate = audioInfo.sample_rate;
@@ -34,7 +35,7 @@ void setup() {
 
 void loop() {
   if (rtspServer.readyToSendAudio()) {
-    size_t bytesRead = i2sStream.read((uint8_t*)sampleBuffer, sizeof(sampleBuffer));
+    size_t bytesRead = i2sStream.readBytes((uint8_t*)sampleBuffer, sizeof(sampleBuffer));
     if (bytesRead) {
       rtspServer.sendRTSPAudio(sampleBuffer, bytesRead / sizeof(int16_t));
     }


### PR DESCRIPTION
## Summary
- Configure I2S stream using RX_MODE with PDM signal type for M5 Atom microphone
- Use readBytes() to fetch audio samples before sending via RTSP

## Testing
- `platformio run` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68a056e78a4c832cb9f3ff4ebfe65339