### PR TITLE
Improve RTSP server logging

### DIFF
--- a/Atom/m5 Sx/M5 Atom rtsp/src/main.cpp
+++ b/Atom/m5 Sx/M5 Atom rtsp/src/main.cpp
@@ -16,8 +16,14 @@ int16_t sampleBuffer[bufferSamples];
 void setup() {
   M5.begin();
   Serial.begin(115200);
+  Serial.println("Starting M5 Atom RTSP server");
+  Serial.println("Connecting to WiFi...");
   WiFi.begin(ssid, password);
-  while (WiFi.status() != WL_CONNECTED) delay(100);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.printf("\nConnected: %s\n", WiFi.localIP().toString().c_str());
 
   // Configure I2S in PDM mode
   I2SConfig cfg = i2sStream.defaultConfig(RX_MODE);
@@ -27,17 +33,30 @@ void setup() {
   cfg.sample_rate = audioInfo.sample_rate;
   cfg.bits_per_sample = audioInfo.bits_per_sample;
   cfg.channels = audioInfo.channels;
-  i2sStream.begin(cfg);
+  Serial.printf("Configuring I2S (WS:%d, DATA:%d, rate:%dHz)\n", cfg.pin_ws, cfg.pin_data, cfg.sample_rate);
+  if (!i2sStream.begin(cfg)) {
+    Serial.println("I2S configuration failed");
+  } else {
+    Serial.println("I2S configured");
+  }
 
   rtspServer.init(RTSPServer::AUDIO_ONLY, 8554, audioInfo.sample_rate);
+  Serial.println("RTSP server initialized");
   Serial.printf("RTSP URL: rtsp://%s:8554/mic\n", WiFi.localIP().toString().c_str());
 }
 
 void loop() {
+  static unsigned long lastLog = 0;
   if (rtspServer.readyToSendAudio()) {
     size_t bytesRead = i2sStream.readBytes((uint8_t*)sampleBuffer, sizeof(sampleBuffer));
+    bool sent = false;
     if (bytesRead) {
       rtspServer.sendRTSPAudio(sampleBuffer, bytesRead / sizeof(int16_t));
+      sent = true;
+    }
+    if (millis() - lastLog > 1000) {
+      Serial.printf("bytesRead: %u, sent: %s\n", bytesRead, sent ? "yes" : "no");
+      lastLog = millis();
     }
   }
   delay(1);


### PR DESCRIPTION
## Summary
- log startup banner and WiFi connection status
- report I2S configuration details and RTSP server initialization
- periodically log audio frame transmission

## Testing
- `pio run -e m5atom -d 'Atom/m5 Sx/M5 Atom rtsp'` *(fails: HTTPClientError while installing espressif32)*

------
https://chatgpt.com/codex/tasks/task_e_68a05c1b5804832ca3e9aac3db2fb7a2