### PR TITLE
Add serial logging for RTSP server client events

### DIFF
--- a/Atom/m5 s3/RTSP mini server/RTSP M5 stack/src/main.cpp
+++ b/Atom/m5 s3/RTSP mini server/RTSP M5 stack/src/main.cpp
@@ -1,18 +1,33 @@
 #include <Arduino.h>
+#include <WiFi.h>
 
-// put function declarations here:
-int myFunction(int, int);
+// Simple RTSP-like server on port 8554
+WiFiServer rtspServer(8554);
 
 void setup() {
-  // put your setup code here, to run once:
-  int result = myFunction(2, 3);
+  Serial.begin(115200);
+  Serial.println("Booting...");
+
+  // Start listening for RTSP clients
+  rtspServer.begin();
+  Serial.println("RTSP server started on port 8554");
 }
 
 void loop() {
-  // put your main code here, to run repeatedly:
+  WiFiClient client = rtspServer.available();
+  if (client) {
+    Serial.println("Client connected");
+
+    // Echo any received data back to the client
+    while (client.connected()) {
+      if (client.available()) {
+        client.write(client.read());
+      }
+      delay(1);
+    }
+
+    Serial.println("Client disconnected");
+    client.stop();
+  }
 }
 
-// put function definitions here:
-int myFunction(int x, int y) {
-  return x + y;
-}


### PR DESCRIPTION
## Summary
- initialize a simple RTSP-like server and start serial logging
- log when server boots, starts, clients connect and disconnect

## Testing
- `pio run` *(fails: NotPlatformIOProjectError: platformio.ini file has not been found)*

------
https://chatgpt.com/codex/tasks/task_e_68a05f8ca808832ca6578df17fd77104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduces a minimal RTSP-style server that starts automatically on boot, allowing Wi‑Fi clients to connect on port 8554.
  * Echoes incoming client data back to the sender, enabling simple connectivity and integration testing.
  * Emits boot, connection, activity, and disconnection logs via Serial for easier diagnostics.
  * Maintains a responsive loop with brief delays to keep connections stable during client sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->