### PR TITLE
Improve RTSP logging and remove vendored dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,7 @@ logs/
 *.log
 *.cache
 .cache/
+# Binary assets
+*.png
+*.bin
+

--- a/Atom/m5 Sx/M5 Atom rtsp/.gitignore
+++ b/Atom/m5 Sx/M5 Atom rtsp/.gitignore
@@ -3,3 +3,8 @@
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .vscode/ipch
+
+# Ignore binary assets
+*.png
+*.bin
+

--- a/Atom/m5 Sx/M5 Atom rtsp/platformio.ini
+++ b/Atom/m5 Sx/M5 Atom rtsp/platformio.ini
@@ -3,6 +3,7 @@ platform    = espressif32
 board       = m5stack-atom
 framework   = arduino
 monitor_speed = 115200
+build_flags = -DRTSP_LOGGING_ENABLED
 
 lib_deps =
     m5stack/M5Unified


### PR DESCRIPTION
## Summary
- drop local ESP32-RTSPServer library and rely on PlatformIO dependency
- enable verbose ESP-IDF logging and add audio send diagnostics
- ignore common binary assets (`*.png`, `*.bin`)

## Testing
- `pio run` *(failed: stalled while installing `espressif32` platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a0976ff9f0832cbc1e5a3578658974

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled verbose RTSP logging for improved troubleshooting via serial output.
  * Clearer startup feedback with explicit success/failure messages during RTSP initialization.
  * Runtime diagnostics when the client isn’t ready to receive audio; streamlined loop logging.

* **Chores**
  * Expanded ignore rules to exclude common binary assets (PNG, BIN) to keep the repository clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->