### PR TITLE
Add internal RAM fallback for RTSP buffer

### DIFF
--- a/Atom/m5 Sx/M5 Atom rtsp/lib/ESP32-RTSPServer/src/ESP32-RTSPServer.cpp
+++ b/Atom/m5 Sx/M5 Atom rtsp/lib/ESP32-RTSPServer/src/ESP32-RTSPServer.cpp
@@ -153,9 +153,11 @@ void RTSPServer::deinit() {
   }
   
   closeSockets();
-  
+
   if (this->rtspStreamBuffer) {
     free(this->rtspStreamBuffer);
+    this->rtspStreamBuffer = NULL;
+    this->rtspStreamBufferSize = 0;
   }
 
   RTSP_LOGI(LOG_TAG, "RTSP server deinitialized.");


### PR DESCRIPTION
## Summary
- allocate RTSP stream buffer with ps_malloc and fall back to heap_caps_malloc with a warning
- release the stream buffer when sessions are torn down and clear pointers during deinit

## Testing
- `pio run` *(fails: HTTPClientError while installing espressif32 platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ba38e1ac832cafbc92e12efb46b7