### PR TITLE
Add PSRAM fallback allocator and disable LTO

### DIFF
--- a/Atom/m5 Sx/M5 Atom rtsp/platformio.ini
+++ b/Atom/m5 Sx/M5 Atom rtsp/platformio.ini
@@ -3,7 +3,7 @@ platform    = espressif32
 board       = m5stack-atom
 framework   = arduino
 monitor_speed = 115200
-build_flags = -DRTSP_LOGGING_ENABLED
+build_flags = -DRTSP_LOGGING_ENABLED -fno-lto
 
 lib_deps =
     m5stack/M5Unified

--- a/Atom/m5 Sx/M5 Atom rtsp/src/psram_fallback.cpp
+++ b/Atom/m5 Sx/M5 Atom rtsp/src/psram_fallback.cpp
@@ -1,0 +1,15 @@
+#include <Arduino.h>
+#include <esp_heap_caps.h>
+#include <esp32-hal-psram.h>
+
+extern "C" void* ps_malloc(size_t size) {
+    if (!psramFound()) {
+        static bool logged = false;
+        if (!logged) {
+            Serial.println("ps_malloc fallback: PSRAM not found, using internal RAM");
+            logged = true;
+        }
+    }
+    return heap_caps_malloc(size, MALLOC_CAP_8BIT);
+}
+


### PR DESCRIPTION
## Summary
- add ps_malloc fallback that allocates from internal RAM and logs when PSRAM is missing
- disable link-time optimization to ensure the fallback object links

## Testing
- `pio run -d 'Atom/m5 Sx/M5 Atom rtsp'` *(fails: stuck installing espressif32 platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d8b96198832cb359f58ee9918266