### PR TITLE
Wrap ps_malloc with PSRAM fallback

### DIFF
--- a/Atom/m5 Sx/M5 Atom rtsp/platformio.ini
+++ b/Atom/m5 Sx/M5 Atom rtsp/platformio.ini
@@ -3,7 +3,7 @@ platform    = espressif32
 board       = m5stack-atom
 framework   = arduino
 monitor_speed = 115200
-build_flags = -DRTSP_LOGGING_ENABLED
+build_flags = -DRTSP_LOGGING_ENABLED -Wl,--wrap=ps_malloc
 
 lib_deps =
     m5stack/M5Unified

--- a/Atom/m5 Sx/M5 Atom rtsp/src/psram_fallback.cpp
+++ b/Atom/m5 Sx/M5 Atom rtsp/src/psram_fallback.cpp
@@ -1,0 +1,17 @@
+#include <Arduino.h>
+#include <esp_heap_caps.h>
+#include <esp_log.h>
+
+extern "C" void* __real_ps_malloc(size_t size);
+
+extern "C" void* __wrap_ps_malloc(size_t size) {
+    if (psramFound()) {
+        return __real_ps_malloc(size);
+    }
+    static bool logged = false;
+    if (!logged) {
+        log_e("PSRAM not found, falling back to heap");
+        logged = true;
+    }
+    return heap_caps_malloc(size, MALLOC_CAP_8BIT);
+}


### PR DESCRIPTION
## Summary
- wrap `ps_malloc` calls so they fall back to heap allocation when PSRAM is unavailable
- enable linker wrapping for `ps_malloc`

## Testing
- `platformio run -d 'Atom/m5 Sx/M5 Atom rtsp'` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dd7c87c8832ca5c09892bf625a63