### PR TITLE
Add PSRAM allocation wrapper

### DIFF
--- a/Atom/m5 Sx/M5 Atom rtsp/platformio.ini
+++ b/Atom/m5 Sx/M5 Atom rtsp/platformio.ini
@@ -3,7 +3,9 @@ platform    = espressif32
 board       = m5stack-atom
 framework   = arduino
 monitor_speed = 115200
-build_flags = -DRTSP_LOGGING_ENABLED
+build_flags =
+  -DRTSP_LOGGING_ENABLED
+  -Wl,-wrap,ps_malloc
 
 lib_deps =
     m5stack/M5Unified

--- a/Atom/m5 Sx/M5 Atom rtsp/src/psram_wrap.c
+++ b/Atom/m5 Sx/M5 Atom rtsp/src/psram_wrap.c
@@ -1,0 +1,19 @@
+#include <stddef.h>
+#include <stdbool.h>
+#include <esp_heap_caps.h>
+#include <esp_log.h>
+
+void* __real_ps_malloc(size_t size);
+
+void* __wrap_ps_malloc(size_t size) {
+    void* ptr = __real_ps_malloc(size);
+    if (ptr) {
+        return ptr;
+    }
+    static bool logged = false;
+    if (!logged) {
+        ESP_LOGW("psram", "PSRAM allocation failed, falling back to internal RAM");
+        logged = true;
+    }
+    return heap_caps_malloc(size, MALLOC_CAP_8BIT);
+}


### PR DESCRIPTION
## Summary
- attempt PSRAM allocation before falling back to internal RAM
- enable ps_malloc linker wrapper

## Testing
- `pio run` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dd84779c832c954da04db085727a