### PR TITLE
Validate microphone data before reporting detection

### DIFF
--- a/Atom/m5 Sx/M5 Atom rtsp/src/main.cpp
+++ b/Atom/m5 Sx/M5 Atom rtsp/src/main.cpp
@@ -41,10 +41,26 @@ void setup() {
     Serial.println("I2S configuration failed");
   } else {
     Serial.println("I2S configured");
-    if (i2sStream.available() >= 0) {
-      Serial.println("Microphone detected/configured");
+
+    // Attempt to read a few samples to validate microphone output
+    int16_t testBuffer[16];
+    size_t bytes = i2sStream.readBytes((uint8_t *)testBuffer, sizeof(testBuffer));
+    bool valid = false;
+
+    if (bytes > 0) {
+      size_t samples = bytes / sizeof(testBuffer[0]);
+      for (size_t i = 0; i < samples; ++i) {
+        if (testBuffer[i] != 0 && testBuffer[i] != -1) {
+          valid = true;
+          break;
+        }
+      }
+    }
+
+    if (valid) {
+      Serial.println("Microphone detected");
     } else {
-      Serial.println("Microphone not detected");
+      Serial.println("Microphone not detected or invalid data");
     }
   }
 


### PR DESCRIPTION
## Summary
- verify microphone availability by reading a small sample after I2S init
- report "Microphone detected" only when buffer contains non-zero/non-0xFFFF data

## Testing
- `pio run -v` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68a0edbba908832c98aef2dafc82ba6b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved microphone detection by validating actual audio samples after initialization.
  * Reduced false positives and improved reliability when the microphone provides no or invalid data.
  * Clearer status messages indicate whether a microphone is detected or not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->