### PR TITLE
Swap RTSP audio sample bytes before transmission

### DIFF
--- a/Atom/m5 Sx/M5 Atom rtsp/src/main.cpp
+++ b/Atom/m5 Sx/M5 Atom rtsp/src/main.cpp
@@ -88,7 +88,12 @@ void loop() {
 
     size_t bytesRead = i2sStream.readBytes((uint8_t*)sampleBuffer, sizeof(sampleBuffer));
     if (bytesRead) {
-      rtspServer.sendRTSPAudio(sampleBuffer, bytesRead / sizeof(int16_t));
+      size_t samples = bytesRead / sizeof(sampleBuffer[0]);
+      for (size_t i = 0; i < samples; ++i) {
+        uint16_t s = static_cast<uint16_t>(sampleBuffer[i]);
+        sampleBuffer[i] = static_cast<int16_t>((s >> 8) | (s << 8));
+      }
+      rtspServer.sendRTSPAudio(sampleBuffer, samples);
       if (!rtspServer.readyToSendAudio()) {
         Serial.println("sendRTSPAudio failed or client not ready");
       }


### PR DESCRIPTION
## Summary
- Swap byte order of audio samples in loop before streaming via RTSP

## Testing
- `pio run -d "Atom/m5 Sx/M5 Atom rtsp"` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68a0efecc1cc832c85135a9167a387cd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected audio byte order in RTSP streams to ensure proper playback across clients, eliminating crackling or garbled sound on some devices.
  * Improved sample count handling when sending audio frames, reducing edge-case errors and enhancing stream stability.
  * Increased compatibility with a wider range of RTSP players without requiring user configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->